### PR TITLE
Advertise Markdown files as "source" files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md linguist-detectable


### PR DESCRIPTION
This change makes Markdown files ["detectable"](https://github.com/github/linguist/blob/master/docs/overrides.md#detectable) by Github as "source" files. As a result, these files will be accounted in repo's language stats.
![image](https://user-images.githubusercontent.com/25753618/210385662-012ff503-cb45-40bc-9b15-68fd313a342b.png)
Markdown will become the main language of the repo.
![image](https://user-images.githubusercontent.com/25753618/210385813-646d4369-ad54-4658-88e9-14d341dc13b3.png)